### PR TITLE
Added posts_scanned.txt appending before it attempts to post, and error handling. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 A python3 script that creates and posts QR codes to reddit for new 3DS hombrebrew posted on the /r/3DShacks subreddit.
 
-    pip install requests
-    pip install praw
-    pip install praw-oauth2util
-    pip install humanize
-    pip install bs4
+    pip install requests==2.9.1
+    pip install praw==3.5.0
+    pip install praw-oauth2util==0.3.4
+    pip install humanize==0.5.1
+    pip install bs4==4.4.1
+	If there is an error installing any of those versions, try installing the newest version instead.
 
     
 You will need to [set up oauth2util](https://github.com/SmBe19/praw-OAuth2Util/blob/master/OAuth2Util/README.md)  

--- a/post_qr.py
+++ b/post_qr.py
@@ -10,7 +10,6 @@ import humanize
 import struct
 from bs4 import BeautifulSoup
 
-
 # sweet mother of imports
 
 def get_cia_info(url):
@@ -161,17 +160,20 @@ def main():
 
                     if comment is not '':  # check if we have anything to post
                         comment += '*[3DS QR Bot](https://github.com/nwk6661/3DS-QR-Poster)*'
-                        submission.add_comment(comment)
+                        posts_scanned.append(submission.id)  # add id to list
+                        with open("posts_scanned.txt", "w") as f:  # write from posts_scanned list to the file
+                            for post_id in posts_scanned:
+                                f.write(post_id + "\n")
+                        try:
+                            submission.add_comment(comment)
+                        except Exception as Error:
+                            run_log.append("An Error Occurred While Posting: "+str(Error))
                         print(comment)
                         log = "Replied to " + submission.id + " on " + time.asctime(time.localtime(time.time()))
                         requests.put("https://api.titledb.com/v1/submission",
                                      data=json.dumps({"url": qrentry[9]}), headers=headers)  # Add to titledb
                         run_log.append(log)  # log post id and time a post was replied to
-                        posts_scanned.append(submission.id)  # add id to list
 
-    with open("posts_scanned.txt", "w") as f:  # write from posts_scanned list to the file
-        for post_id in posts_scanned:
-            f.write(post_id + "\n")
 
     with open("run_log.txt", "w") as l:  # write from the run_log to the file
         for log_entry in run_log:

--- a/post_qr.py
+++ b/post_qr.py
@@ -170,8 +170,10 @@ def main():
                             run_log.append("An Error Occurred While Posting: "+str(Error))
                         print(comment)
                         log = "Replied to " + submission.id + " on " + time.asctime(time.localtime(time.time()))
-                        requests.put("https://api.titledb.com/v1/submission",
-                                     data=json.dumps({"url": qrentry[9]}), headers=headers)  # Add to titledb
+                        try:
+                            requests.put("https://api.titledb.com/v1/submission",data=json.dumps({"url": qrentry[9]}), headers=headers)  # Add to titledb
+                        except Exception as Error:
+                            run_log.append("An Error Occurred While Adding the CIA to TitleDB: "+str(Error))
                         run_log.append(log)  # log post id and time a post was replied to
 
 


### PR DESCRIPTION
Hey, I looked at and tested the code, and I found that if an exception occurred during "submission.add_comment(comment)" [Line 164](https://github.com/nwk6661/3DS-QR-Poster/blob/45b4da7105c76bb99980100da9ac02873835a1fb/post_qr.py#L164), the bot would still post the QR code to reddit, but your script would immediately end (meaning that it wouldn't get a chance to write to posts_scanned.txt.) 

The 2 solutions that I came up with were moving the writing of posts_scanned.txt up before submission.add_comment(comment), and error handling so that if an error in submission.add_comment(comment) does happen, the script writes the error to the log and continues. 

This should solve #11 if the error happening was the same one I experienced. 